### PR TITLE
Overloaded method for jetID

### DIFF
--- a/interface/bbggTools.h
+++ b/interface/bbggTools.h
@@ -43,6 +43,7 @@ public:
 	bool isPhoID(const flashgg::Photon* pho, vector<double> cuts);
 	bool isPhoISO(edm::Ptr<flashgg::DiPhotonCandidate> pho, int whichPho, vector<double> cuts, vector<double> nhCorr, vector<double> phCorr);
 	bool isPhoISO(edm::Ptr<flashgg::DiPhotonCandidate> pho, int whichPho, vector<double> cuts);
+        bool isJetID(const flashgg::Jet* jet);
         bool isJetID(edm::Ptr<flashgg::Jet> jet);
 	void setRho(double rho) {rho_ = rho;}
 	

--- a/src/bbggTools.cc
+++ b/src/bbggTools.cc
@@ -44,7 +44,7 @@ bool bbggTools::isJetID(const flashgg::Jet* jet)
 
 bool bbggTools::isJetID(edm::Ptr<flashgg::Jet> jet)
 {
-  return bbggTools::isJetID(jet);
+  return bbggTools::isJetID(&(*jet));
 }
 
 std::map<int, vector<double> > bbggTools::getWhichID (std::string wpoint)
@@ -241,7 +241,7 @@ bool bbggTools::isPhoID(const flashgg::Photon* pho, vector<double> cuts)
 
 bool bbggTools::isPhoID(edm::Ptr<flashgg::Photon> pho, vector<double> cuts)
 {
-  return bbggTools::isPhoID(pho,cuts);
+  return bbggTools::isPhoID(&(*pho),cuts);
 }
 
 

--- a/src/bbggTools.cc
+++ b/src/bbggTools.cc
@@ -12,7 +12,7 @@ using namespace std;
 
 bool DEBUG = 0;
 
-bool bbggTools::isJetID(edm::Ptr<flashgg::Jet> jet)
+bool bbggTools::isJetID(const flashgg::Jet* jet)
 {
     double NHF = jet->neutralHadronEnergyFraction();
     double NEMF = jet->neutralEmEnergyFraction();
@@ -40,6 +40,11 @@ bool bbggTools::isJetID(edm::Ptr<flashgg::Jet> jet)
     }
     
     return 1;
+}
+
+bool bbggTools::isJetID(edm::Ptr<flashgg::Jet> jet)
+{
+  return bbggTools::isJetID(jet);
 }
 
 std::map<int, vector<double> > bbggTools::getWhichID (std::string wpoint)
@@ -212,7 +217,7 @@ double bbggTools::DeltaR(bbggTools::LorentzVector vec1, bbggTools::LorentzVector
 	return sqrt(R2);
 }
 
-bool bbggTools::isPhoID(edm::Ptr<flashgg::Photon> pho, vector<double> cuts)
+bool bbggTools::isPhoID(const flashgg::Photon* pho, vector<double> cuts)
 {
 	if(rho_ == -10 ){
 		cout << "[bbggTools::isPhoID] You have to do tools->setRho(rho)!" << endl;
@@ -234,25 +239,11 @@ bool bbggTools::isPhoID(edm::Ptr<flashgg::Photon> pho, vector<double> cuts)
 	return isid;
 }
 
-bool bbggTools::isPhoID(const flashgg::Photon* pho, vector<double> cuts)
+bool bbggTools::isPhoID(edm::Ptr<flashgg::Photon> pho, vector<double> cuts)
 {
-	if(rho_ == -10 ){
-		cout << "[bbggTools::isPhoID] You have to do tools->setRho(rho)!" << endl;
-		return -1;
-	}
-	if(cuts.size() != 3){
-		cout << "[bbggTools::isPhoID] ERROR: the input cuts vector must have size three (sieie/hoe/el-veto)" << endl;
-		return 0;
-	}
-	bool isid = true;
-	double hoe = pho->hadronicOverEm();
-	double sieie = pho->full5x5_sigmaIetaIeta();
-	
-	if( hoe > cuts[0] ) 	isid = false;
-  	if( sieie > cuts[1] ) isid = false;
-	
-	return isid;
+  return bbggTools::isPhoID(pho,cuts);
 }
+
 
 bool bbggTools::isPhoISO(edm::Ptr<flashgg::DiPhotonCandidate> dipho, int whichPho, vector<double> cuts)
 {


### PR DESCRIPTION
 The new jetID method is needed so that my code compiles.
Also, removed a duplicate code for phoID(ptr pho), which now calls the alternative phoId(pho*).
My code works with these changes, but I have not tried treemakers within the package. But they should work too.
