### PR TITLE
Scripts to add RonRes re-shaping weights to trees

### DIFF
--- a/plugins/bbggTree.cc
+++ b/plugins/bbggTree.cc
@@ -782,8 +782,6 @@ bbggTree::beginJob()
     tree->Branch("DiJetDiPho_DR_2", &DiJetDiPho_DR_2, "DiJetDiPho_DR_2/F");
     tree->Branch("PhoJetMinDr", &PhoJetMinDr, "PhoJetMinDr/F");
 
-    tree->Branch("evt", &evt, "evt/D");
-
     std::map<std::string, std::string> replacements;
     globVar_->bookTreeVariables(tree, replacements);
 

--- a/plugins/bbggTree.cc
+++ b/plugins/bbggTree.cc
@@ -782,6 +782,8 @@ bbggTree::beginJob()
     tree->Branch("DiJetDiPho_DR_2", &DiJetDiPho_DR_2, "DiJetDiPho_DR_2/F");
     tree->Branch("PhoJetMinDr", &PhoJetMinDr, "PhoJetMinDr/F");
 
+    tree->Branch("evt", &evt, "evt/D");
+
     std::map<std::string, std::string> replacements;
     globVar_->bookTreeVariables(tree, replacements);
 

--- a/scripts/ReweightTrees/README.md
+++ b/scripts/ReweightTrees/README.md
@@ -1,4 +1,5 @@
 
+## Producing the weights (by Alexandra)
 The input files in lxplus are in
 inputLM = "/afs/cern.ch/work/z/zghiche/public/ForXanda/NRDir_LM_350/"
 inputHM = "/afs/cern.ch/work/z/zghiche/public/ForXanda/NRDir_HM_350/"

--- a/scripts/ReweightTrees/addWeights.py
+++ b/scripts/ReweightTrees/addWeights.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+from ROOT import TFile, TTree, TH1D
+from array import array
+
+fSig = TFile('/afs/cern.ch/user/a/andrey/public/HH/NonResAll.root','read')
+
+tSig = fSig.Get('fsDir/TCVARS')
+tSig.Print()
+
+
+wFile = TFile("fout.root","read")
+#wFile = TFile("teste_weight.root","read")
+#wTree = wFile.Get("TCVARS")
+h = {}
+h['wBox'] = wFile.Get('e_wBox')
+
+leavesBench = "wBox/D"
+leavesOut   = ""
+for b in xrange(1,13):
+    name = 'bench'+str(b)
+    h[name] = wFile.Get('e_'+name)
+    leavesBench+=':%s/D'%name
+    for o in xrange(1,7):
+        name = 'bench'+str(b)+'_out'+str(o)
+        h[name] = wFile.Get('e_'+name)
+        if len(leavesOut):
+            leavesOut+=':%s/D'%name
+        else:
+            leavesOut+='%s/D'%name
+
+newFile = TFile("newFilename.root","RECREATE")
+newTree = tSig.CloneTree(0)
+
+
+wArrBench = array('d',[0]*13)
+wArrOut   = array('d',[0]*(12*6))
+
+newBranch1 = newTree.Branch("benchmarks" , wArrBench, leavesBench)
+newBranch2 = newTree.Branch("outliers" ,   wArrOut,   leavesOut)
+
+alist, i = [], 0
+while tSig.GetEntry(i):
+    i += 1
+
+    fNum = tSig.GetLeaf( "file" ).GetValue()
+    eNum = tSig.GetLeaf( "o_evt" ).GetValue()
+    if eNum < 10:
+        print fNum, eNum
+
+    for b in xrange(1,13):
+        name = 'bench'+str(b)
+        wArrBench[b-1] = h[name].GetBinContent(int(fNum*50000+eNum))
+    for b in xrange(1,13):
+        for o in xrange(1,7):
+            name = 'bench'+str(b)+'_out'+str(o)
+            wArrOut[(b-1)*6+o-1] = h[name].GetBinContent(int(fNum*50000+eNum))
+
+    newTree.Fill()
+
+newTree.Write()

--- a/scripts/ReweightTrees/weightTest.py
+++ b/scripts/ReweightTrees/weightTest.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+from ROOT import *
+gROOT.SetBatch()
+
+
+f = TFile('/afs/cern.ch/user/a/andrey/public/HH/NonRes_weights_from_Xandra_v0.root','OPEN')
+t = f.Get('TCVARS')
+
+
+t.Draw('mHH>>h(200,0,2500)','file==0')
+c1.SaveAs('mHH_Box_file.png')
+t.Draw('mHH>>h(200,0,2500)','wBox')
+c1.SaveAs('mHH_Box_wei.png')
+
+'''
+for n in range(1,13):
+    print n
+    t.Draw('mHH>>h(200,0,2500)','file=='+str(n))
+    c1.SaveAs('mHH_'+str(n)+'_file.png')
+   
+    t.Draw('mHH>>h(200,0,2500)','bench'+str(n))
+    c1.SaveAs('mHH_'+str(n)+'_weight.png')
+
+'''
+
+#t.Draw('(file*50000+evt)>>e_Box(650000,1,650001)','wBox')
+#c1.SaveAs('evt.png')
+
+fout = TFile('fout.root','recreate')
+
+name = 'wBox'
+t.Draw('(file*50000+evt)>>e_'+name+'(650000,1,650001)',name)
+gPad.GetPrimitive('e_'+name).Write()
+for b in xrange(1,13):
+    name = 'bench'+str(b)
+    t.Draw('(file*50000+evt)>>e_'+name+'(650000,1,650001)',name)
+    gPad.GetPrimitive('e_'+name).Write()
+    for o in xrange(1,7):
+        name = 'bench'+str(b)+'_out'+str(o)
+        t.Draw('(file*50000+evt)>>e_'+name+'(650000,1,650001)',name)
+        gPad.GetPrimitive('e_'+name).Write()
+        
+
+
+# Manually cross check some weights from dew events
+for a in xrange(46000, 46020):
+    print a, e_wBox.GetBinContent(12*50000+a)
+t.Scan('file:evt:wBox','file==12&&evt>46000&&evt<46020')
+


### PR DESCRIPTION
Here I add two scripts.
1. weightTest.py will read the input tree form Alexandra and create large Histograms which map the (file number, event number) to a single weight.
Such histogram is created for each weight in the input tree.
2. addWeights.py inserts the weights into a tree with final results. This is tested on my own TCVARS tree, but should also work on any tree, which has an "evt" variable and if the file number is provided. Script needs to be modified accordingly 

PS. After implementing script (1) I discovered a better way to do this (I think), which is TTree::BuildIndex method. So, instead of creating histograms one can have a tree indexed by (file,evt) combination. I have not tried to implement it though, not sure if it will work.
https://root.cern.ch/doc/master/classTTree.html#a3f6b5bb591ff7a5bd0b06eea6c12b998

PPS. The reason for creating TH1 hist is not to loop over the tree every time for each event - that would take ages. Geting BinContent() of a histogram is much faster.
