### PR TITLE
Include event and run numbers in Limit Trees

### DIFF
--- a/bin/LimitTreeMaker.C
+++ b/bin/LimitTreeMaker.C
@@ -25,8 +25,9 @@ int Process(string file, string outFile, string mtotMin, string mtotMax,string s
     option.append(doKinFit);
     option.append(";");
     option.append(doMX);
+    gROOT->SetMacroPath(".:./src/");
     cout << "[LimitTreeMaker:Process] Option parsing: " << option << endl;
-    iTree->Process("flashgg/bbggTools/src/bbggLTMaker.cc+", TString(option)); 
+    iTree->Process("bbggLTMaker.cc+", TString(option)); 
     delete iFile;
     return 1;
 }

--- a/interface/bbggLTMaker.h
+++ b/interface/bbggLTMaker.h
@@ -51,9 +51,6 @@ public :
 // Fixed size dimensions of array or collections stored in the TTree if any.
 
    // Declaration of leaf types
-   ULong64_t         event;
-   UInt_t  run;
-
    vector<double>   *genWeights;
    Double_t         genTotalWeight;
    LorentzVector    *leadingPhoton;
@@ -78,6 +75,10 @@ public :
    LorentzVector    *diHiggsCandidate_KF;
    Int_t	isSignal;
    Int_t	isPhotonCR;
+
+   ULong64_t event;
+   UInt_t    run;
+
 
    // List of branches
    TBranch        *b_event;   //!

--- a/interface/bbggLTMaker.h
+++ b/interface/bbggLTMaker.h
@@ -28,6 +28,9 @@ public :
 //   Output file and tree
    TTree *outTree;
    TFile *outFile;
+
+   ULong64_t o_evt;
+   UInt_t o_run;
    Int_t           o_category;
    Double_t        o_normalization;
    Double_t        o_weight;
@@ -48,6 +51,9 @@ public :
 // Fixed size dimensions of array or collections stored in the TTree if any.
 
    // Declaration of leaf types
+   ULong64_t         event;
+   UInt_t  run;
+
    vector<double>   *genWeights;
    Double_t         genTotalWeight;
    LorentzVector    *leadingPhoton;
@@ -74,6 +80,9 @@ public :
    Int_t	isPhotonCR;
 
    // List of branches
+   TBranch        *b_event;   //!
+   TBranch        *b_run;   //!
+
    TBranch        *b_genWeights;   //!
    TBranch        *b_genTotalWeight;   //!
    TBranch        *b_leadingPhoton;   //!
@@ -155,6 +164,9 @@ void bbggLTMaker::Init(TTree *tree)
    if (!tree) return;
    fChain = tree;
 //   fChain->SetMakeClass(1);
+
+   fChain->SetBranchAddress("event", &event, &b_event);
+   fChain->SetBranchAddress("run", &run, &b_run);
 
    fChain->SetBranchAddress("genWeights", &genWeights, &b_genWeights);
    fChain->SetBranchAddress("genTotalWeight", &genTotalWeight, &b_genTotalWeight);

--- a/python/parameters.py
+++ b/python/parameters.py
@@ -116,6 +116,7 @@ _PhotonMVAEstimator			=	cms.untracked.string("PhotonMVAEstimatorRun2Spring15NonT
 
 _doJetRegression			=	cms.untracked.uint32(0)
 
-_bRegFile					=	cms.untracked.string("/afs/cern.ch/work/r/rateixei/work/DiHiggs/flashggJets/CMSSW_7_4_15/src/flashgg/bbggTools/Weights/BRegression/TMVARegression_BDTG.weights.xml")
+_bRegFile=cms.untracked.string("/afs/cern.ch/user/a/andrey/work/hh/CMSSW_8_0_8_patch1/src/flashgg/bbggTools/Weights/BRegression/TMVARegression_BDTG.weights.xml")
+#_bRegFile=cms.FileInPath("flashgg/bbggTools/Weights/BRegression/TMVARegression_BDTG.weights.xml")
 
 _is2016						=	cms.untracked.uint32(1)

--- a/src/bbggLTMaker.cc
+++ b/src/bbggLTMaker.cc
@@ -69,6 +69,9 @@ void bbggLTMaker::Begin(TTree * /*tree*/)
        std::cout << "[bbggLTMaker::Begin] Your input file name is not a root file!" << std::endl;
        TSelector::Abort("Wrong input!");
    } else {
+       o_evt = 0;
+       o_run = 0;
+
        o_weight = 0;
        o_bbMass = 0;
        o_ggMass = 0;
@@ -82,6 +85,9 @@ void bbggLTMaker::Begin(TTree * /*tree*/)
        outTree->Branch("mjj", &o_bbMass, "o_bbMass/D");
        outTree->Branch("mgg", &o_ggMass, "o_ggMass/D");
        outTree->Branch("mtot", &o_bbggMass, "o_bbggMass/D"); //
+
+       outTree->Branch("evt", &o_evt, "o_evt/l");
+       outTree->Branch("run", &o_run, "o_run/i");
    }
 /*
    std::cout << "[bbggLTMaker::Begin] Category chosen: " << cat << std::endl;
@@ -131,6 +137,9 @@ Bool_t bbggLTMaker::Process(Long64_t entry)
    bbggLTMaker::GetEntry(entry);
    if( entry%1000 == 0 ) std::cout << "[bbggLTMaker::Process] Reading entry #" << entry << endl;   
    
+   o_evt = event;
+   o_evt = run;
+
    o_weight = genTotalWeight*normalization;
    o_bbMass = dijetCandidate->M();
    o_ggMass = diphotonCandidate->M();

--- a/src/bbggLTMaker.cc
+++ b/src/bbggLTMaker.cc
@@ -135,11 +135,11 @@ Bool_t bbggLTMaker::Process(Long64_t entry)
    // The return value is currently not used.
 
    bbggLTMaker::GetEntry(entry);
-   if( entry%1000 == 0 ) std::cout << "[bbggLTMaker::Process] Reading entry #" << entry << endl;   
-   
+   if( entry%1000 == 0 ) std::cout << "[bbggLTMaker::Process] Reading entry #" << entry 
+				   << "\t Event = "<<event<<"  Run = "<<run<<endl;   
    o_evt = event;
-   o_evt = run;
-
+   o_run = run;
+   
    o_weight = genTotalWeight*normalization;
    o_bbMass = dijetCandidate->M();
    o_ggMass = diphotonCandidate->M();

--- a/test/RunJobs/MakeTrees_FLASHgg_bkg.py
+++ b/test/RunJobs/MakeTrees_FLASHgg_bkg.py
@@ -48,7 +48,7 @@ process.bbggtree.vertexes = cms.InputTag("offlineSlimmedPrimaryVertices")
 process.bbggtree.puInfo=cms.InputTag("slimmedAddPileupInfo")
 process.bbggtree.lumiWeight = cms.double(1.0)
 process.bbggtree.intLumi = cms.double(1.0)
-process.bbggtree.puReWeight=cms.bool(True)
+process.bbggtree.puReWeight=cms.bool(False)
 process.bbggtree.puBins=cms.vdouble()
 process.bbggtree.dataPu=cms.vdouble()
 process.bbggtree.mcPu=cms.vdouble()
@@ -70,6 +70,8 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 customize.setDefault("maxEvents",-1)
 customize.setDefault("targetLumi",2.58e+3)
 
+print "I'M HERE 1.2"
+
 customize.register('doSelection',
 					False,
 					VarParsing.VarParsing.multiplicity.singleton,
@@ -86,18 +88,26 @@ customize.register('nPromptPhotons',
 					VarParsing.VarParsing.varType.int,
 					'Number of prompt photons to be selected - to use this, set doDoubleCountingMitigation=1')
 customize.register('PURW',
-				1,
+				0,
 				VarParsing.VarParsing.multiplicity.singleton,
 				VarParsing.VarParsing.varType.bool,
 				"Do PU reweighting? Doesn't work on 76X")
 
 
+print "I'M HERE 1.3"
+
 # call the customization
 customize(process)
+print "I'M HERE 1.4"
 
-process.bbggtree.puReWeight=cms.bool( customize.PURW )
+process.bbggtree.puReWeight=cms.bool( bool(customize.PURW) )
+print "I'M HERE 1.5"
+
 if customize.PURW == False:
-	process.bbggtree.puTarget = cms.vdouble()
+        process.bbggtree.puTarget = cms.vdouble()
+        print "I'M HERE 1.6"
+
+
 print "I'M HERE 2"
 
 maxEvents = 5


### PR DESCRIPTION
Event number in the limit trees is needed for non-resonant reweightings