### PR TITLE
Adding non-resonant weights from a root file

### DIFF
--- a/interface/bbggTools.h
+++ b/interface/bbggTools.h
@@ -50,7 +50,9 @@ public:
     std::map<int, vector<double> > getWhichID (std::string wpoint);
     std::map<int, vector<double> > getWhichISO (std::string wpoint);
     
-	double getCHisoToCutValue(const flashgg::DiPhotonCandidate * dipho, int whichPho);
+    float getCosThetaStar_CS(TLorentzVector h1, TLorentzVector h2, float ebeam = 3500);
+    
+    double getCHisoToCutValue(const flashgg::DiPhotonCandidate * dipho, int whichPho);
 	double getCHisoToCutValue(edm::Ptr<flashgg::DiPhotonCandidate> dipho, int whichPho);
     
     double getNHisoToCutValue(const flashgg::Photon* pho);

--- a/python/bbggTree_cfi.py
+++ b/python/bbggTree_cfi.py
@@ -65,6 +65,7 @@ bbggtree = cms.EDAnalyzer('bbggTree',
 	PhotonMVAEstimator=param._PhotonMVAEstimator,
 	doJetRegression=param._doJetRegression,
 	bRegFile=param._bRegFile,
-	is2016=param._is2016
+	is2016=param._is2016,
+	doNonResWeights=param._doNonResWeights
 #	doSelectionTree=param._doSelectionTree
 )

--- a/python/parameters.py
+++ b/python/parameters.py
@@ -3,6 +3,8 @@ import FWCore.ParameterSet.Config as cms
 import flashgg.Taggers.flashggTags_cff as flashggTags
 
 
+_doNonResWeights = cms.untracked.bool(False)
+
 _doPhotonCR				=	cms.untracked.uint32(1)
 _triggerTag				=	cms.InputTag("TriggerResults", "", "HLT")
 _myTriggers				=	cms.untracked.vstring(
@@ -114,9 +116,7 @@ _MVAPhotonID                            =       cms.untracked.vdouble(0.374, 0.3
 #MVA user float
 _PhotonMVAEstimator			=	cms.untracked.string("PhotonMVAEstimatorRun2Spring15NonTrig25nsV2p1Values")
 
-_doJetRegression			=	cms.untracked.uint32(1)
-
-#_bRegFile=cms.untracked.string("/afs/cern.ch/user/a/andrey/work/hh/CMSSW_8_0_8_patch1/src/flashgg/bbggTools/Weights/BRegression/TMVARegression_BDTG.weights.xml")
+_doJetRegression			=	cms.untracked.uint32(0)
 _bRegFile      =  cms.untracked.FileInPath("flashgg/bbggTools/data/BRegression/TMVARegression_BDTG.weights.xml")
 
 _is2016						=	cms.untracked.uint32(1)

--- a/src/bbggTools.cc
+++ b/src/bbggTools.cc
@@ -214,6 +214,28 @@ std::map<std::string,int> bbggTools::TriggerSelection(std::vector<std::string> m
 }
 
 
+float bbggTools::getCosThetaStar_CS(TLorentzVector h1, TLorentzVector h2, float ebeam) {
+  // cos theta star angle in the Collins Soper frame
+  // Copied directly from here: https://github.com/ResonantHbbHgg/Selection/blob/master/selection.h#L3367-L3385
+  TLorentzVector p1, p2;
+  p1.SetPxPyPzE(0, 0,  ebeam, ebeam);
+  p2.SetPxPyPzE(0, 0, -ebeam, ebeam);
+
+  TLorentzVector hh;
+  hh = h1 + h2;
+
+  TVector3 boost = - hh.BoostVector();
+  p1.Boost(boost);
+  p2.Boost(boost);
+  h1.Boost(boost);
+
+  TVector3 CSaxis = p1.Vect().Unit() - p2.Vect().Unit();
+  CSaxis.Unit();
+
+  return cos(   CSaxis.Angle( h1.Vect().Unit() )    );
+}
+
+
 bool bbggTools::isJetID(edm::Ptr<flashgg::Jet> jet)
 {
     double NHF = jet->neutralHadronEnergyFraction();

--- a/test/RunJobs/MakeTrees_FLASHgg_Nres.py
+++ b/test/RunJobs/MakeTrees_FLASHgg_Nres.py
@@ -1,0 +1,178 @@
+import FWCore.ParameterSet.Config as cms
+from flashgg.bbggTools.microAOD_RadFiles import *
+from flashgg.bbggTools.microAOD_GravFiles import *
+from flashgg.bbggTools.More_microAOD_DJet40Inf import *
+from flashgg.bbggTools.pColors import *
+import flashgg.Taggers.flashggTags_cff as flashggTags
+
+##### Arguments
+#import flashgg.bbggTools.VarParsing as opts
+#options = opts.VarParsing('analysis')
+#------- Add extra option
+#options.register('doSelection',
+#					False,
+#					opts.VarParsing.multiplicity.singleton,
+#					opts.VarParsing.varType.bool,
+#					'False: Make tree before selection; True: Make tree after selection')
+#options.register('doDoubleCountingMitigation',
+#					False,
+#					opts.VarParsing.multiplicity.singleton,
+#					opts.VarParsing.varType.bool,
+#					'False: Do not remove double counted photons from QCD/GJet/DiPhotonJets; True: Remove double counted photons from QCD/GJet/DiPhotonJets')
+#options.register('nPromptPhotons',
+#					0,
+#					opts.VarParsing.multiplicity.singleton,
+#					opts.VarParsing.varType.int,
+#					'Number of prompt photons to be selected - to use this, set doDoubleCountingMitigation=1')
+#
+#-------
+#
+#options.parseArguments()
+
+#maxEvents = 5
+#if options.maxEvents:
+#        maxEvents = int(options.maxEvents)
+
+#inputFile = "/store/user/rateixei/flashgg/RunIISpring15-50ns/Spring15BetaV2/GluGluToRadionToHHTo2B2G_M-650_narrow_13TeV-madgraph/RunIISpring15-50ns-Spring15BetaV2-v0-RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/150804_164203/0000/myMicroAODOutputFile_1.root" #RadFiles['650']
+#if options.inputFiles:
+#        inputFile = options.inputFiles
+
+#outputFile = "rest_rad700.root"
+#if options.outputFile:
+#        outputFile = options.outputFile
+######
+process = cms.Process("bbggtree")
+process.load("flashgg.bbggTools.bbggTree_cfi")
+process.bbggtree.rho = cms.InputTag('fixedGridRhoAll')
+process.bbggtree.vertexes = cms.InputTag("offlineSlimmedPrimaryVertices")
+process.bbggtree.puInfo=cms.InputTag("slimmedAddPileupInfo")
+process.bbggtree.lumiWeight = cms.double(1.0)
+process.bbggtree.intLumi = cms.double(1.0)
+process.bbggtree.puReWeight=cms.bool(False)
+process.bbggtree.puBins=cms.vdouble()
+process.bbggtree.dataPu=cms.vdouble()
+process.bbggtree.mcPu=cms.vdouble()
+
+process.bbggtree.doNonResWeights=cms.untracked.bool(True)
+
+print "I'M HERE 1"
+
+process.source = cms.Source("PoolSource",
+    # replace 'myfile.root' with the source file you want to use
+    fileNames = cms.untracked.vstring("test.root")
+)
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32( 2000 )
+
+# import flashgg customization
+from flashgg.MetaData.JobConfig import customize
+import FWCore.ParameterSet.VarParsing as VarParsing
+# set default options if needed
+customize.setDefault("maxEvents",-1)
+customize.setDefault("targetLumi",2.58e+3)
+
+print "I'M HERE 1.2"
+
+customize.register('doSelection',
+					False,
+					VarParsing.VarParsing.multiplicity.singleton,
+					VarParsing.VarParsing.varType.bool,
+					'False: Make tree before selection; True: Make tree after selection')
+customize.register('doDoubleCountingMitigation',
+					False,
+					VarParsing.VarParsing.multiplicity.singleton,
+					VarParsing.VarParsing.varType.bool,
+					'False: Do not remove double counted photons from QCD/GJet/DiPhotonJets; True: Remove double counted photons from QCD/GJet/DiPhotonJets')
+customize.register('nPromptPhotons',
+					0,
+					VarParsing.VarParsing.multiplicity.singleton,
+					VarParsing.VarParsing.varType.int,
+					'Number of prompt photons to be selected - to use this, set doDoubleCountingMitigation=1')
+customize.register('PURW',
+				0,
+				VarParsing.VarParsing.multiplicity.singleton,
+				VarParsing.VarParsing.varType.bool,
+				"Do PU reweighting? Doesn't work on 76X")
+
+
+print "I'M HERE 1.3"
+
+# call the customization
+customize(process)
+print "I'M HERE 1.4"
+
+process.bbggtree.puReWeight=cms.bool( bool(customize.PURW) )
+print "I'M HERE 1.5"
+
+if customize.PURW == False:
+        process.bbggtree.puTarget = cms.vdouble()
+        print "I'M HERE 1.6"
+
+
+print "I'M HERE 2"
+
+maxEvents = 5
+if customize.maxEvents:
+        maxEvents = int(customize.maxEvents)
+
+inputFile = "/store/user/rateixei/flashgg/RunIISpring15-50ns/Spring15BetaV2/GluGluToRadionToHHTo2B2G_M-650_narrow_13TeV-madgraph/RunIISpring15-50ns-Spring15BetaV2-v0-RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/150804_164203/0000/myMicroAODOutputFile_1.root" #RadFiles['650']
+if customize.inputFiles:
+        inputFile = customize.inputFiles
+
+outputFile = "rest_rad700.root"
+if customize.outputFile:
+        outputFile = customize.outputFile
+
+print customize.inputFiles, customize.outputFile, customize.maxEvents, customize.doSelection, customize.doDoubleCountingMitigation, customize.nPromptPhotons
+
+
+#process.load("FWCore.MessageService.MessageLogger_cfi")
+
+#process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(maxEvents) )
+#process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32( 2000 )
+
+## Available mass points:
+# RadFiles: 320, 340, 350, 400, 600, 650, 700
+# GravFiles: 260, 270, 280, 320, 350, 500, 550
+#NonResPhys14 = 'file:/afs/cern.ch/work/r/rateixei/work/DiHiggs/FLASHggPreSel/CMSSW_7_4_0_pre9/src/flashgg/MicroAOD/test/hhbbgg_hggVtx.root'
+
+#process.source = cms.Source("PoolSource",
+#    # replace 'myfile.root' with the source file you want to use
+#    fileNames = cms.untracked.vstring(
+#        customize.inputFiles
+#    )
+#)
+
+print "I'M HERE 3"
+
+#process.load("flashgg.bbggTools.bbggTree_cfi")
+process.load("flashgg.Taggers.flashggTags_cff")
+process.bbggtree.OutFileName = cms.untracked.string(outputFile)
+
+print bcolors.OKBLUE + "########################################################################" + bcolors.ENDC
+print bcolors.OKBLUE + "#  _   _  _   _  _      _                     _____                    #" + bcolors.ENDC
+print bcolors.OKBLUE + "# | | | || | | || |    | |                   |_   _|                   #" + bcolors.ENDC
+print bcolors.OKBLUE + "# | |_| || |_| || |__  | |__    __ _   __ _    | |   _ __   ___   ___  #" + bcolors.ENDC
+print bcolors.OKBLUE + "# |  _  ||  _  || '_ \ | '_ \  / _` | / _` |   | |  | '__| / _ \ / _ \ #" + bcolors.ENDC
+print bcolors.OKBLUE + "# | | | || | | || |_) || |_) || (_| || (_| |   | |  | |   |  __/|  __/ #" + bcolors.ENDC
+print bcolors.OKBLUE + "# \_| |_/\_| |_/|_.__/ |_.__/  \__, | \__, |   \_/  |_|    \___| \___| #" + bcolors.ENDC
+print bcolors.OKBLUE + "#                               __/ |  __/ |                           #" + bcolors.ENDC
+print bcolors.OKBLUE + "#                              |___/  |___/                            #" + bcolors.ENDC
+print bcolors.OKBLUE + "########################################################################" + bcolors.ENDC
+print bcolors.FAIL + "Is it performing the analysis selection?",customize.doSelection, bcolors.ENDC
+print bcolors.FAIL + "Is it removing double counted photons from QCD/GJet/DiPhotonJets?",customize.doDoubleCountingMitigation, bcolors.ENDC
+if customize.doSelection is True:
+	process.bbggtree.doSelectionTree = cms.untracked.uint32(1)
+if customize.doSelection is False:
+	process.bbggtree.doSelectionTree = cms.untracked.uint32(0)
+if customize.doDoubleCountingMitigation is True:
+	process.bbggtree.doDoubleCountingMitigation = cms.untracked.uint32(1)
+	process.bbggtree.nPromptPhotons = cms.untracked.uint32(customize.nPromptPhotons)
+	print "Number of prompt photons in DiPhotonCandidate:",customize.nPromptPhotons
+if customize.doDoubleCountingMitigation is False:
+	process.bbggtree.doDoubleCountingMitigation = cms.untracked.uint32(0)
+
+#process.p = cms.Path(process.bbggtree)
+
+process.p = cms.Path(flashggTags.flashggUnpackedJets*process.bbggtree)

--- a/test/RunJobs/RunJobs_NonRes.json
+++ b/test/RunJobs/RunJobs_NonRes.json
@@ -1,0 +1,47 @@
+{
+    "processes" : {
+        "GluGluToHHTo2B2G_node_10_13TeV-madgraph" : [
+            "/GluGluToHHTo2B2G_node_10_13TeV-madgraph"
+        ],
+        "GluGluToHHTo2B2G_node_11_13TeV-madgraph" : [
+            "/GluGluToHHTo2B2G_node_11_13TeV-madgraph"
+        ],
+        "GluGluToHHTo2B2G_node_12_13TeV-madgraph" : [
+            "/GluGluToHHTo2B2G_node_12_13TeV-madgraph"
+        ],
+        "GluGluToHHTo2B2G_node_13_13TeV-madgraph" : [
+            "/GluGluToHHTo2B2G_node_13_13TeV-madgraph"
+        ],
+        "GluGluToHHTo2B2G_node_2_13TeV-madgraph" : [
+            "/GluGluToHHTo2B2G_node_2_13TeV-madgraph"
+        ],
+        "GluGluToHHTo2B2G_node_3_13TeV-madgraph" : [
+            "/GluGluToHHTo2B2G_node_3_13TeV-madgraph"
+        ],
+        "GluGluToHHTo2B2G_node_4_13TeV-madgraph" : [
+            "/GluGluToHHTo2B2G_node_4_13TeV-madgraph"
+        ],
+        "GluGluToHHTo2B2G_node_5_13TeV-madgraph" : [
+            "/GluGluToHHTo2B2G_node_5_13TeV-madgraph"
+        ],
+        "GluGluToHHTo2B2G_node_6_13TeV-madgraph" : [
+            "/GluGluToHHTo2B2G_node_6_13TeV-madgraph"
+        ],
+        "GluGluToHHTo2B2G_node_7_13TeV-madgraph" : [
+            "/GluGluToHHTo2B2G_node_7_13TeV-madgraph"
+        ],
+        "GluGluToHHTo2B2G_node_8_13TeV-madgraph" : [
+            "/GluGluToHHTo2B2G_node_8_13TeV-madgraph"
+        ],
+        "GluGluToHHTo2B2G_node_9_13TeV-madgraph" : [
+            "/GluGluToHHTo2B2G_node_9_13TeV-madgraph"
+        ],
+        "GluGluToHHTo2B2G_node_SM_13TeV-madgraph" : [
+            "/GluGluToHHTo2B2G_node_SM_13TeV-madgraph"
+        ],
+        "GluGluToHHTo2B2G_node_box_13TeV-madgraph" : [
+            "/GluGluToHHTo2B2G_node_box_13TeV-madgraph"
+        ]
+   },
+	"cmdLine" : "campaign=HHbbgg_Signal76X_RegVars doDoubleCountingMitigation=0 targetLumi=2.63e+3 doSelection=1 PURW=0"
+}

--- a/test/RunJobs/RunJobs_Test.json
+++ b/test/RunJobs/RunJobs_Test.json
@@ -3,8 +3,8 @@
         "GluGluToHHTo2B2G_node_9_13TeV-madgraph" : [
             "/GluGluToHHTo2B2G_node_9_13TeV-madgraph"
         ],
-        "GluGluToHHTo2B2G_node_SM_13TeV-madgraph" : [
-            "/GluGluToHHTo2B2G_node_SM_13TeV-madgraph"
+        "GluGluToHHTo2B2G_node_2_13TeV-madgraph" : [
+            "/GluGluToHHTo2B2G_node_2_13TeV-madgraph"
         ]
    },
 	"cmdLine" : "campaign=HHbbgg_Signal76X_RegVars doDoubleCountingMitigation=0 targetLumi=2.58e+3 doSelection=1 puTarget='1.34e+05,6.34e+05,8.42e+05,1.23e+06,2.01e+06,4.24e+06,1.26e+07,4.88e+07,1.56e+08,3.07e+08,4.17e+08,4.47e+08,4.04e+08,3.05e+08,1.89e+08,9.64e+07,4.19e+07,1.71e+07,7.85e+06,4.2e+06,2.18e+06,9.43e+05,3.22e+05,8.9e+04,2.16e+04,5.43e+03,1.6e+03,551,206,80.1,31.2,11.9,4.38,1.54,0.518,0.165,0.0501,0.0144,0.00394,0.00102,0.000251,5.87e-05,1.3e-05,2.74e-06,5.47e-07,1.04e-07,1.86e-08,3.18e-09,5.16e-10,9.35e-11,0,0'"


### PR DESCRIPTION
Adding a possibility to add the weights from mHH_cosThetaStar distribution.
* The input file is provided by Olivier, I have it copied at: **/afs/cern.ch/user/a/andrey/public/HH/weights_v1_1507_points.root** (not committed to git!)
This file should be copied to **bbggTools/data** directory.
* The option to run this weights is set up with ```process.bbggtree.doNonResWeights=cms.untracked.bool(True)``` in a config file.
* Notice, the costhetaStar definition added to bbggTools code.
* The weighs are added as an array: **NRWeights[1507]**

